### PR TITLE
Adding `/articles/recent/lite` endpoint. (#20)

### DIFF
--- a/backend/src/main/java/news_compiler/controller/ArticleReaderController.java
+++ b/backend/src/main/java/news_compiler/controller/ArticleReaderController.java
@@ -37,6 +37,16 @@ public class ArticleReaderController {
     }
 
     /**
+     * Returns a lightweight version of the articles fetched in the last 24 hours.
+     * These articles do not contain the body of the article, to reduce payload size.
+     * @return a list of the most recently fetched articles with a null body.
+     */
+    @GetMapping("/recent/lite")
+    public List<ArticleDto> getRecentArticlesLite() {
+        return articleService.getRecentlyFetchedLite();
+    }
+
+    /**
      * Returns an article by its ID.
      * @param id the ID of the article to fetch
      * @return the article with the given ID

--- a/backend/src/main/java/news_compiler/service/ArticleService.java
+++ b/backend/src/main/java/news_compiler/service/ArticleService.java
@@ -80,6 +80,21 @@ public class ArticleService {
     }
 
     /**
+     * Returns a lightweight version of the articles fetched in the last 24 hours.
+     * These articles do not contain the body of the article, to reduce payload size.
+     *
+     * @return a list of the most recently fetched articles with a null body.
+     */
+    public List<ArticleDto> getRecentlyFetchedLite() {
+        List<ArticleDto> articles = getRecentlyFetched();
+
+        // Set the body to null to reduce payload size
+        articles.forEach(article -> article.setBody(null));
+
+        return articles;
+    }
+
+    /**
      * Writes articles to the database.
      *
      * @param articles the articles to write

--- a/backend/src/test/java/news_compiler/BaseTest.java
+++ b/backend/src/test/java/news_compiler/BaseTest.java
@@ -17,7 +17,8 @@ public abstract class BaseTest {
 
     /* Starts the MySQL container before any tests are run as a 'singleton'. */
     static {
-        mySQLContainer = new MySQLContainer<>("mysql:latest")
+        // TODO: Update the MySQL version when TestContainers supports it
+        mySQLContainer = new MySQLContainer<>("mysql:8.0")
                 .withDatabaseName("my_test_db")
                 .withUsername("my_user")
                 .withPassword("my_password");

--- a/backend/src/test/java/news_compiler/controller/ArticleReaderControllerTest.java
+++ b/backend/src/test/java/news_compiler/controller/ArticleReaderControllerTest.java
@@ -222,4 +222,25 @@ class ArticleReaderControllerTest extends BaseTest {
         mockMVC.perform(get("/api/articles/1000"))
                 .andExpect(status().isNotFound());  // Ensure that the request was unsuccessful
     }
+
+    /**
+     * Tests that the <code>getRecentArticlesLite</code> endpoint functions as intended.
+     * This test will not check many of the contents of the articles or the edge cases around
+     * fetching articles, as those are already covered by other tests.
+     * This test will only check that the body of the articles is null to reduce payload size.
+     * @throws Exception if the test fails or if there is an issue with the GET request
+     */
+    @Test
+    @Transactional
+    void getRecentArticlesLite() throws Exception {
+        // Ensure that the controller returns the correct articles
+        mockMVC.perform(get("/api/articles/recent/lite"))
+                .andExpect(status().isOk())
+                .andExpect(content().string(containsString(testArticles.get(0).getTitle())))
+                .andExpect(content().string(containsString(testArticles.get(2).getTitle())))
+                .andExpect(content().string(containsString(testArticles.get(1).getTitle())))
+                .andExpect(content().string(not(containsString(testArticles.get(0).getBody()))))
+                .andExpect(content().string(not(containsString(testArticles.get(2).getBody()))))
+                .andExpect(content().string(not(containsString(testArticles.get(1).getBody()))));
+    }
 }

--- a/frontend/src/services/ArticleService.js
+++ b/frontend/src/services/ArticleService.js
@@ -20,7 +20,7 @@ const REST_API_BASE_URL = `${import.meta.env.VITE_API_URL}/articles`;
  * }[], status: Number}>>}
  */
 export const getRecentArticles = () => axios.get(
-    `${REST_API_BASE_URL}/recent`);
+    `${REST_API_BASE_URL}/recent/lite`);
 
 /**
  * Retrieves an article by its ID.


### PR DESCRIPTION
* [Debug] Updated MySQL version.

TestContainers is not compatible with newer MySQL versions.

* [Implementation] Add lightweight endpoint for recently fetched articles